### PR TITLE
[codex] Refresh Enterprise page docs

### DIFF
--- a/content/enterprise/_index.md
+++ b/content/enterprise/_index.md
@@ -3,72 +3,235 @@ type: enterprise
 draft: false
 layout: single
 title: "Enterprise Edition"
-description: "Unlock advanced features for your organization with DevOps Maturity Enterprise."
+description: "Deployment, governance, API, licensing, and pricing for DevOps Maturity Enterprise."
 ---
 
 # DevOps Maturity Enterprise
 
-Take your DevOps maturity assessment to the next level with the Enterprise Edition — designed for teams and organizations that need advanced controls, private deployment, and dedicated support.
+DevOps Maturity Assessment Enterprise (DMAE) is the commercial edition of the open-source DevOps Maturity project. It extends the core assessment workflow with multi-team governance, compliance features, enterprise reporting, and commercial license enforcement.
 
-## OSS vs Enterprise
+## What Enterprise Adds
+
+- Multi-tenancy for organizations, teams, and departments
+- Role-based access control (RBAC) for enterprise administration
+- JWT authentication, browser sessions, and API key access
+- Custom assessment criteria and industry-specific templates
+- Advanced reporting, trend analysis, benchmark comparison, and data export
+- Audit logging and outbound webhooks
+- SSO and LDAP/Active Directory integration skeletons
+- Vendor-issued license management with runtime policy enforcement
+
+## Feature Matrix
 
 | Feature | Open Source | Enterprise |
-|---------|:-----------:|:----------:|
-| DevOps Maturity Specification | ✅ | ✅ |
-| Web UI Assessment | ✅ | ✅ |
-| CLI Assessment | ✅ | ✅ |
-| Maturity Badges | ✅ | ✅ |
-| Community Support | ✅ | ✅ |
-| Custom Criteria / Extensions | ❌ | ✅ |
-| Private / On-Premise Deployment | ❌ | ✅ |
-| Single Sign-On (SSO / LDAP / SAML) | ❌ | ✅ |
-| Role-Based Access Control (RBAC) | ❌ | ✅ |
-| Team & Organization Management | ❌ | ✅ |
-| Audit Logs | ❌ | ✅ |
-| Advanced Analytics & Reporting | ❌ | ✅ |
-| REST API Access | ❌ | ✅ |
-| Custom Branding | ❌ | ✅ |
-| Compliance Reporting (SOC 2, ISO 27001) | ❌ | ✅ |
-| Dedicated Support & SLA | ❌ | ✅ |
+| --- | :---: | :---: |
+| DevOps maturity assessment | ✅ | ✅ |
+| Score levels (WIP -> GOLD) | ✅ | ✅ |
+| Social OAuth (Google / GitHub) | ✅ | ✅ |
+| Multi-tenancy (organizations) | ❌ | ✅ |
+| Team / department management | ❌ | ✅ |
+| Role-based access control (RBAC) | ❌ | ✅ |
+| JWT authentication + API keys | ❌ | ✅ |
+| Custom assessment criteria | ❌ | ✅ |
+| Industry templates | ❌ | ✅ |
+| Advanced reporting & trend analysis | ❌ | ✅ |
+| Team benchmark comparison | ❌ | ✅ |
+| Data export | ❌ | ✅ |
+| Audit logging | ❌ | ✅ |
+| Outbound webhooks | ❌ | ✅ |
+| SSO (SAML / OIDC) skeleton | ❌ | ✅ |
+| LDAP / Active Directory sync skeleton | ❌ | ✅ |
+| License management | ❌ | ✅ |
 
-## Enterprise-Only Features
+## Quick Start
 
-### 🔒 Private / On-Premise Deployment
+### 1. Install dependencies
 
-Run DevOps Maturity entirely within your own infrastructure. Keep sensitive assessment data on your own servers, comply with data residency requirements, and integrate with your internal network.
+```bash
+pip install -e ".[dev]"
+```
 
-### 🔑 Single Sign-On (SSO)
+### 2. Create a signing keypair
 
-Integrate with your organization's identity provider via SAML 2.0, LDAP, or OIDC. Streamline access management and enforce centralized authentication policies.
+This is a vendor-side step. Keep the private key offline.
 
-### 👥 Team & Organization Management
+```bash
+dmae-enterprise generate-license-keypair \
+  --private-key-out ./secrets/vendor-license-private.pem \
+  --public-key-out ./secrets/license-public.pem
+```
 
-Organize assessments by team, project, or business unit. Assign roles and permissions with fine-grained Role-Based Access Control (RBAC) to ensure the right people have the right access.
+### 3. Issue a trial or paid license
 
-### 📊 Advanced Analytics & Reporting
+```bash
+dmae-enterprise issue-license \
+  --private-key-file ./secrets/vendor-license-private.pem \
+  --org acme-corp \
+  --tier trial \
+  --expires 2026-05-09
+```
 
-Gain deeper insights with cross-team trend analysis, historical score tracking, and exportable compliance reports. Map your DevOps controls to frameworks like SLSA, NIST, and ISO 20243.
+### 4. Configure the environment
 
-### 🔌 REST API Access
+```env
+JWT_SECRET_KEY=change-me-before-production
+DATABASE_URL=sqlite:///./enterprise.db
+LICENSE_KEY=<vendor-issued-license>
+LICENSE_PUBLIC_KEY_FILE=./secrets/license-public.pem
+LICENSE_ENFORCEMENT_MODE=strict
+DMAE_RUNTIME_CONFIG_FILE=./.dmae/runtime-config.json
+PUBLIC_APP_URL=http://localhost:8000
+EMAIL_DELIVERY_MODE=log
+EMAIL_BRAND_NAME=DMAE Enterprise
+EMAIL_SUPPORT_ADDRESS=support@dmae.local
+```
 
-Integrate DevOps Maturity assessments into your existing DevOps toolchain via a fully documented REST API. Automate score collection and reporting within your CI/CD pipelines.
+### 5. Start the server
 
-### 🛡️ Audit Logs
+```bash
+dmae-enterprise server
+```
 
-Maintain a complete, tamper-resistant record of all assessment activities, configuration changes, and user actions for compliance and security auditing purposes.
+First-run setup from the browser will:
 
-### 🎨 Custom Branding
+- accept the signed license key
+- create the first `SUPER_ADMIN`
+- create the first organization
+- persist runtime license overrides for self-hosted restarts
 
-White-label the interface with your organization's logo, colors, and domain to deliver a seamless internal user experience.
+### 6. Optional CLI bootstrap
 
-### 🤝 Dedicated Support & SLA
+```bash
+dmae-enterprise bootstrap-admin \
+  --username platform-admin \
+  --email admin@example.com \
+  --org-name "Acme Corp" \
+  --org-slug acme
+```
 
-Get priority support from the DevOps Maturity team, guaranteed response times, and access to a dedicated customer success manager.
+## UI Endpoints
 
----
+- Setup UI: `http://localhost:8000/`
+- Login UI: `http://localhost:8000/login`
+- Invite accept UI: `http://localhost:8000/welcome?token=...`
+- Password reset UI: `http://localhost:8000/reset-password?token=...`
+- App landing page: `http://localhost:8000/app`
+- Swagger UI: `http://localhost:8000/enterprise/docs`
+- ReDoc: `http://localhost:8000/enterprise/redoc`
+- Health check: `http://localhost:8000/health`
 
-## Get Started with Enterprise
+The browser workspace at `/app` includes:
 
-Ready to take DevOps Maturity to the enterprise level? Contact us to learn more or request a demo.
+- organization overview and effective limits
+- license tier and feature visibility
+- user listing, email invitation, password reset links, and account activation controls
+- team listing and creation
+- recent audit activity
+
+## Runtime Enforcement
+
+The server enforces commercial policy at runtime:
+
+- `strict` mode refuses startup without a valid, unexpired license
+- license tiers gate premium features such as webhooks, advanced reporting, export, and benchmark reporting
+- user, team, and monthly assessment quotas are enforced at request time
+- trial, starter, and enterprise tiers can each carry custom overrides for users, teams, and assessments
+
+## Authentication And API Access
+
+Login with email and password:
+
+```bash
+curl -X POST http://localhost:8000/enterprise/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@example.com","password":"secret"}'
+```
+
+Use the returned bearer token:
+
+```bash
+curl http://localhost:8000/enterprise/organizations \
+  -H "Authorization: Bearer <access_token>"
+```
+
+Or use an API key when the current license includes `api_access`:
+
+```bash
+curl http://localhost:8000/enterprise/organizations \
+  -H "X-API-Key: dmae_<your_api_key>"
+```
+
+Browser sessions use `HttpOnly` cookies. Invite acceptance and password reset flows issue one-time links that land on `/welcome` and `/reset-password`.
+
+For local development, keep `EMAIL_DELIVERY_MODE=log` and the admin UI will show link previews after sending an invite or reset, plus recent delivery history in the Email Delivery panel. For production, switch to `EMAIL_DELIVERY_MODE=smtp`, configure SMTP settings, and set `EMAIL_BRAND_NAME` and `EMAIL_SUPPORT_ADDRESS` to match customer-facing emails.
+
+## Key API Endpoints
+
+| Endpoint | Description |
+| --- | --- |
+| `POST /enterprise/auth/login` | Authenticate and receive JWT tokens |
+| `POST /enterprise/auth/session/login` | Authenticate and establish browser session cookies |
+| `POST /enterprise/auth/refresh` | Refresh an access token |
+| `GET /enterprise/email/settings` | Inspect effective email delivery configuration |
+| `POST /enterprise/email/test` | Send a test email with the current delivery settings |
+| `GET /enterprise/auth/action-link` | Inspect an invite or password reset link |
+| `POST /enterprise/auth/action-link/consume` | Complete an invite or password reset |
+| `POST /enterprise/organizations` | Create an organization |
+| `POST /enterprise/organizations/{id}/teams` | Create a team |
+| `POST /enterprise/organizations/{id}/users` | Create a user and send invite link |
+| `POST /enterprise/organizations/{id}/users/{user_id}/invite-link` | Reissue an invite link |
+| `POST /enterprise/organizations/{id}/users/{user_id}/reset-password` | Send a password reset link |
+| `GET /enterprise/organizations/{id}/email-deliveries` | View invite/reset delivery outcomes |
+| `POST /enterprise/organizations/{id}/email-deliveries/{delivery_id}/retry` | Retry a failed or previewed invite/reset email |
+| `POST /enterprise/organizations/{id}/assessments` | Submit an assessment |
+| `GET /enterprise/organizations/{id}/reports/summary` | Summary dashboard |
+| `GET /enterprise/organizations/{id}/reports/trends` | Score trend over time |
+| `GET /enterprise/organizations/{id}/reports/benchmark` | Team comparison |
+| `GET /enterprise/organizations/{id}/reports/export` | Export assessments |
+| `GET /enterprise/organizations/{id}/audit-logs` | View audit trail |
+| `POST /enterprise/organizations/{id}/api-keys` | Generate API key |
+| `POST /enterprise/organizations/{id}/webhooks` | Register webhook |
+
+## Licensing And Pricing
+
+The current commercial baseline is a simple B2B annual subscription model sold per organization, with seat bands instead of pure per-seat billing.
+
+| Tier | Recommended packaging | Suggested starting price |
+| --- | --- | --- |
+| `trial` | 14-30 days, 10 users, 3 teams, 50 assessments/month | Free |
+| `starter` | Up to 100 users, 20 teams, 500 assessments/month | USD 6,000/year |
+| `enterprise` | Up to 500 users included, SSO/export/benchmark/priority support | From USD 18,000/year |
+
+Recommended overage policy:
+
+- Additional 100 users: +USD 2,000/year
+- Additional 1000 assessments/month: +USD 1,500/year
+- Premium onboarding or private support channel: quoted separately
+
+Operational license policy:
+
+- default enforcement mode is `strict`
+- trial customers receive a signed `trial` license with an expiry date
+- paying customers receive a signed `starter` or `enterprise` license
+- renewals are handled by issuing a fresh key before expiry
+- upgrades are handled by issuing a new key with a higher tier or larger limits
+
+The runtime verifies licenses with an Ed25519 public key. Keep the private key offline and only distribute the public key to deployed environments.
+
+## Customer Lifecycle
+
+1. Generate a signing keypair once and store the private key offline.
+2. Send the public key with the deployment package or bake it into the hosted environment.
+3. Issue a `trial` key for evaluation.
+4. When the customer converts, issue a `starter` or `enterprise` key with the agreed expiry and limits.
+5. Before expiry, issue a renewal key and rotate `LICENSE_KEY`.
+
+## Default Criteria Fallback
+
+If the open-source submodule is not checked out, the enterprise service falls back to a built-in assessment criteria set so scoring still works in a standalone deployment.
+
+## Get Started With Enterprise
+
+Use Enterprise when you need centralized governance, private deployment, compliance-oriented reporting, and licensed commercial support around the DevOps Maturity workflow.
 
 {{< enterprise-cta >}}

--- a/content/enterprise/_index.zh.md
+++ b/content/enterprise/_index.zh.md
@@ -3,72 +3,235 @@ type: enterprise
 draft: false
 layout: single
 title: "企业版"
-description: "通过 DevOps 成熟度企业版，解锁适合您组织的高级功能。"
+description: "DevOps 成熟度企业版的部署、治理、API、许可与定价说明。"
 ---
 
 # DevOps 成熟度企业版
 
-通过企业版将您的 DevOps 成熟度评估提升到全新水平 —— 专为需要高级管控、私有部署和专属支持的团队与组织而设计。
+DevOps Maturity Assessment Enterprise（DMAE）是 DevOps Maturity 开源项目的商业版本。它在核心评估流程之上增加了多团队治理、合规能力、企业级报表和商业许可证运行时控制。
 
-## 开源版 vs 企业版
+## 企业版新增能力
+
+- 面向组织、团队和部门的多租户模型
+- 面向企业管理场景的基于角色访问控制（RBAC）
+- JWT 鉴权、浏览器会话和 API Key 访问
+- 自定义评估标准和行业模板
+- 高级报表、趋势分析、团队基准对比和数据导出
+- 审计日志和出站 Webhook
+- SSO 与 LDAP / Active Directory 集成骨架
+- 由供应商签发的许可证管理与运行时策略校验
+
+## 功能矩阵
 
 | 功能 | 开源版 | 企业版 |
-|------|:------:|:------:|
-| DevOps 成熟度规范 | ✅ | ✅ |
-| Web UI 评估 | ✅ | ✅ |
-| CLI 评估 | ✅ | ✅ |
-| 成熟度徽章 | ✅ | ✅ |
-| 社区支持 | ✅ | ✅ |
-| 自定义评估项 / 扩展 | ❌ | ✅ |
-| 私有 / 本地部署 | ❌ | ✅ |
-| 单点登录（SSO / LDAP / SAML） | ❌ | ✅ |
+| --- | :---: | :---: |
+| DevOps 成熟度评估 | ✅ | ✅ |
+| 评分等级（WIP -> GOLD） | ✅ | ✅ |
+| 社交 OAuth（Google / GitHub） | ✅ | ✅ |
+| 多租户（组织） | ❌ | ✅ |
+| 团队 / 部门管理 | ❌ | ✅ |
 | 基于角色的访问控制（RBAC） | ❌ | ✅ |
-| 团队与组织管理 | ❌ | ✅ |
+| JWT 鉴权 + API Key | ❌ | ✅ |
+| 自定义评估标准 | ❌ | ✅ |
+| 行业模板 | ❌ | ✅ |
+| 高级报表与趋势分析 | ❌ | ✅ |
+| 团队基准对比 | ❌ | ✅ |
+| 数据导出 | ❌ | ✅ |
 | 审计日志 | ❌ | ✅ |
-| 高级分析与报告 | ❌ | ✅ |
-| REST API 访问 | ❌ | ✅ |
-| 自定义品牌 | ❌ | ✅ |
-| 合规报告（SOC 2、ISO 27001） | ❌ | ✅ |
-| 专属支持与 SLA | ❌ | ✅ |
+| 出站 Webhook | ❌ | ✅ |
+| SSO（SAML / OIDC）骨架 | ❌ | ✅ |
+| LDAP / Active Directory 同步骨架 | ❌ | ✅ |
+| 许可证管理 | ❌ | ✅ |
 
-## 企业版专属功能
+## 快速开始
 
-### 🔒 私有 / 本地部署
+### 1. 安装依赖
 
-在您自己的基础设施上完整运行 DevOps 成熟度评估系统。将敏感评估数据保留在您的服务器上，满足数据驻留要求，并与内部网络无缝集成。
+```bash
+pip install -e ".[dev]"
+```
 
-### 🔑 单点登录（SSO）
+### 2. 生成许可证签名密钥对
 
-通过 SAML 2.0、LDAP 或 OIDC 与您组织的身份提供商集成。简化访问管理，强制执行集中式身份验证策略。
+这是供应商侧步骤，私钥应离线保管。
 
-### 👥 团队与组织管理
+```bash
+dmae-enterprise generate-license-keypair \
+  --private-key-out ./secrets/vendor-license-private.pem \
+  --public-key-out ./secrets/license-public.pem
+```
 
-按团队、项目或业务部门组织评估。通过细粒度的基于角色的访问控制（RBAC）分配角色和权限，确保合适的人员拥有合适的访问权限。
+### 3. 签发试用或正式许可证
 
-### 📊 高级分析与报告
+```bash
+dmae-enterprise issue-license \
+  --private-key-file ./secrets/vendor-license-private.pem \
+  --org acme-corp \
+  --tier trial \
+  --expires 2026-05-09
+```
 
-通过跨团队趋势分析、历史评分追踪和可导出的合规报告获得更深入的洞察。将您的 DevOps 控制映射到 SLSA、NIST 和 ISO 20243 等框架。
+### 4. 配置环境变量
 
-### 🔌 REST API 访问
+```env
+JWT_SECRET_KEY=change-me-before-production
+DATABASE_URL=sqlite:///./enterprise.db
+LICENSE_KEY=<vendor-issued-license>
+LICENSE_PUBLIC_KEY_FILE=./secrets/license-public.pem
+LICENSE_ENFORCEMENT_MODE=strict
+DMAE_RUNTIME_CONFIG_FILE=./.dmae/runtime-config.json
+PUBLIC_APP_URL=http://localhost:8000
+EMAIL_DELIVERY_MODE=log
+EMAIL_BRAND_NAME=DMAE Enterprise
+EMAIL_SUPPORT_ADDRESS=support@dmae.local
+```
 
-通过完整文档化的 REST API 将 DevOps 成熟度评估集成到您现有的 DevOps 工具链中。在 CI/CD 流水线中自动化评分收集和报告。
+### 5. 启动服务
 
-### 🛡️ 审计日志
+```bash
+dmae-enterprise server
+```
 
-维护所有评估活动、配置更改和用户操作的完整、防篡改记录，用于合规和安全审计目的。
+首次通过浏览器初始化时会：
 
-### 🎨 自定义品牌
+- 接收签名许可证
+- 创建首个 `SUPER_ADMIN`
+- 创建首个组织
+- 持久化自托管部署重启后仍可用的运行时许可证配置
 
-使用您组织的徽标、颜色和域名对界面进行白标定制，提供无缝的内部用户体验。
+### 6. 可选的 CLI 引导
 
-### 🤝 专属支持与 SLA
+```bash
+dmae-enterprise bootstrap-admin \
+  --username platform-admin \
+  --email admin@example.com \
+  --org-name "Acme Corp" \
+  --org-slug acme
+```
 
-获得 DevOps 成熟度团队的优先支持、有保障的响应时间以及专属客户成功经理的服务。
+## UI 入口
 
----
+- 初始化页面：`http://localhost:8000/`
+- 登录页面：`http://localhost:8000/login`
+- 邀请接受页面：`http://localhost:8000/welcome?token=...`
+- 密码重置页面：`http://localhost:8000/reset-password?token=...`
+- 应用首页：`http://localhost:8000/app`
+- Swagger UI：`http://localhost:8000/enterprise/docs`
+- ReDoc：`http://localhost:8000/enterprise/redoc`
+- 健康检查：`http://localhost:8000/health`
+
+`/app` 浏览器工作台包含：
+
+- 组织概览和生效中的资源配额
+- 当前许可证等级及功能可见性
+- 用户列表、邮件邀请、密码重置链接和账户激活控制
+- 团队列表与创建
+- 最近审计活动
+
+## 运行时控制
+
+服务在运行时会强制执行商业策略：
+
+- `strict` 模式下，没有有效且未过期许可证时将拒绝启动
+- 许可证等级会控制高级功能，例如 webhook、高级报表、导出和 benchmark 报表
+- 用户数、团队数和每月评估次数会在请求时校验
+- `trial`、`starter` 和 `enterprise` 都可以带有用户、团队和评估额度的自定义覆盖
+
+## 鉴权与 API 访问
+
+通过邮箱和密码登录：
+
+```bash
+curl -X POST http://localhost:8000/enterprise/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@example.com","password":"secret"}'
+```
+
+使用返回的 Bearer Token：
+
+```bash
+curl http://localhost:8000/enterprise/organizations \
+  -H "Authorization: Bearer <access_token>"
+```
+
+当当前许可证包含 `api_access` 时，也可以使用 API Key：
+
+```bash
+curl http://localhost:8000/enterprise/organizations \
+  -H "X-API-Key: dmae_<your_api_key>"
+```
+
+浏览器会话使用 `HttpOnly` Cookie。邀请接受和密码重置流程会生成一次性链接，分别落到 `/welcome` 和 `/reset-password`。
+
+本地开发建议保留 `EMAIL_DELIVERY_MODE=log`，这样管理界面会显示邀请或重置邮件的链接预览和投递历史。生产环境则应切换到 `EMAIL_DELIVERY_MODE=smtp`，配置 SMTP 参数，并设置 `EMAIL_BRAND_NAME` 与 `EMAIL_SUPPORT_ADDRESS`。
+
+## 关键 API 接口
+
+| 接口 | 说明 |
+| --- | --- |
+| `POST /enterprise/auth/login` | 登录并返回 JWT Token |
+| `POST /enterprise/auth/session/login` | 登录并建立浏览器会话 Cookie |
+| `POST /enterprise/auth/refresh` | 刷新访问令牌 |
+| `GET /enterprise/email/settings` | 查看当前邮件投递配置 |
+| `POST /enterprise/email/test` | 发送测试邮件 |
+| `GET /enterprise/auth/action-link` | 查看邀请或重置链接状态 |
+| `POST /enterprise/auth/action-link/consume` | 完成邀请接受或密码重置 |
+| `POST /enterprise/organizations` | 创建组织 |
+| `POST /enterprise/organizations/{id}/teams` | 创建团队 |
+| `POST /enterprise/organizations/{id}/users` | 创建用户并发送邀请链接 |
+| `POST /enterprise/organizations/{id}/users/{user_id}/invite-link` | 重新签发邀请链接 |
+| `POST /enterprise/organizations/{id}/users/{user_id}/reset-password` | 发送密码重置链接 |
+| `GET /enterprise/organizations/{id}/email-deliveries` | 查看邀请/重置邮件投递结果 |
+| `POST /enterprise/organizations/{id}/email-deliveries/{delivery_id}/retry` | 重试失败或仅预览的邮件投递 |
+| `POST /enterprise/organizations/{id}/assessments` | 提交一次评估 |
+| `GET /enterprise/organizations/{id}/reports/summary` | 汇总看板 |
+| `GET /enterprise/organizations/{id}/reports/trends` | 评分趋势 |
+| `GET /enterprise/organizations/{id}/reports/benchmark` | 团队对比 |
+| `GET /enterprise/organizations/{id}/reports/export` | 导出评估数据 |
+| `GET /enterprise/organizations/{id}/audit-logs` | 查看审计日志 |
+| `POST /enterprise/organizations/{id}/api-keys` | 生成 API Key |
+| `POST /enterprise/organizations/{id}/webhooks` | 注册 Webhook |
+
+## 许可与定价
+
+当前商业基线是按组织销售的 B2B 年度订阅模型，采用席位区间，而不是纯按 seat 单价计费。
+
+| 套餐 | 建议打包方式 | 建议起售价 |
+| --- | --- | --- |
+| `trial` | 14-30 天，10 用户，3 团队，每月 50 次评估 | 免费 |
+| `starter` | 最多 100 用户，20 团队，每月 500 次评估 | USD 6,000/年 |
+| `enterprise` | 默认含 500 用户，含 SSO / 导出 / benchmark / 优先支持 | USD 18,000/年起 |
+
+建议的超额策略：
+
+- 每增加 100 用户：+USD 2,000/年
+- 每增加 1000 次/月评估：+USD 1,500/年
+- 高级导入实施或私有支持通道：单独报价
+
+运行许可证策略：
+
+- 默认强制模式是 `strict`
+- 试用客户会拿到带到期时间的签名 `trial` 许可证
+- 付费客户会拿到签名 `starter` 或 `enterprise` 许可证
+- 续费通过到期前签发新许可证完成
+- 升级通过签发更高套餐或更大额度的新许可证完成
+
+运行时使用 Ed25519 公钥验证许可证。私钥应离线保管，只向部署环境分发公钥。
+
+## 客户生命周期
+
+1. 只生成一次签名密钥对，并将私钥离线保存。
+2. 将公钥随部署包提供，或直接内置到托管环境中。
+3. 为评估阶段签发 `trial` 许可证。
+4. 客户转化后，按约定的到期时间和额度签发 `starter` 或 `enterprise` 许可证。
+5. 到期前重新签发续费许可证，并轮换 `LICENSE_KEY`。
+
+## 默认标准回退
+
+如果开源子模块没有检出，企业版服务会回退到内置评估标准，保证独立部署时依然可以完成评分。
 
 ## 开始使用企业版
 
-准备好将 DevOps 成熟度提升至企业级别了吗？联系我们了解更多信息或申请演示。
+当你需要集中治理、私有部署、面向合规的报表能力，以及围绕 DevOps Maturity 工作流的商业支持时，就应该使用企业版。
 
 {{< enterprise-cta >}}


### PR DESCRIPTION
## Summary

This PR refreshes the Enterprise page with the latest documentation from the `devops-maturity-enterprise` repository.

It updates both the English and Chinese Enterprise pages to include:

- the current enterprise feature matrix
- quick start and deployment guidance
- UI and API endpoint documentation
- runtime licensing and quota enforcement details
- pricing and customer lifecycle information

## Why

The existing Enterprise page was still a high-level marketing summary and did not reflect the current product documentation from the enterprise repository.

## Impact

Users browsing the Enterprise page now see the latest product and commercial documentation directly on the site.

## Validation

- `hugo --minify`
