### PR TITLE
feat: add JSON Schema, SLSA mapping, and positioning clarification

### DIFF
--- a/MAPPING-SLSA.md
+++ b/MAPPING-SLSA.md
@@ -1,0 +1,42 @@
+# DevOps Maturity ↔ SLSA Mapping
+
+This document maps DevOps Maturity criteria to relevant [SLSA (Supply-chain Levels for Software Artifacts)](https://slsa.dev/) concepts, helping teams understand where the two frameworks overlap.
+
+## Relationship
+
+DevOps Maturity is a **broader DevOps baseline assessment**, not a supply-chain security standard. It covers build, test, security, supply chain, analysis, and reporting — a wider surface than SLSA's focused scope on artifact integrity and provenance.
+
+**DevOps Maturity does not replace SLSA.** SLSA provides a rigorous, verifiable supply-chain integrity framework. DevOps Maturity can help teams assess their readiness across the full DevOps spectrum, and the supply-chain-related criteria map naturally to SLSA requirements.
+
+## Criteria Mapping
+
+| DevOps Maturity | Description | SLSA Direction |
+|---|---|---|
+| **D401** Documented Build Process | Build steps are version-controlled and documented | Build process transparency — a prerequisite for Build Track reproducibility |
+| **D402** CI/CD as Code | Pipelines and infrastructure defined as code | Build process definition — SLSA requires the build process to be defined and verifiable |
+| **D403** Artifact Signing | Build artifacts are cryptographically signed | Artifact integrity / provenance distribution — aligns with SLSA's requirement for signed attestations |
+| **D404** Dependency Pinning | All dependencies pinned to exact versions | Reproducibility support — reduces supply-chain attack surface |
+| **D405** SBOM Generation | Automatically generate Software Bill of Materials | Supply-chain transparency — complements SLSA provenance with dependency inventory |
+| **D603** Compliance Mapping & Auditability | Map controls to standards, provide audit-ready reports | Verified properties / audit evidence — supports the consumption and verification side |
+
+## Where They Diverge
+
+SLSA provides detailed requirements that go beyond DevOps Maturity:
+
+- **Build Track** (Levels 1–3): Defines specific requirements for hermetic builds, isolated environments, parameterless builds, and ephemeral builders.
+- **Source Track**: Covers source integrity protections (two-person review, branch protection, verified history).
+- **Attestation Format**: SLSA defines standardized in-toto attestation formats (provenance, VSA).
+- **Verification**: SLSA specifies policy-based verification of attestations.
+
+DevOps Maturity covers areas SLSA does not:
+
+- **Quality** (D2xx): Unit testing, functional testing, code coverage, accessibility.
+- **Analysis** (D5xx): Static analysis, dynamic analysis, linting.
+- **Reporting** (D6xx): Notifications, attached reports.
+- **Security Scanning** (D3xx): Vulnerability and license scanning.
+
+## Practical Path
+
+A team can use DevOps Maturity as a **first-step health check** to identify gaps across the entire DevOps lifecycle. Once the supply-chain security criteria (D4xx) are addressed, SLSA provides the next level of rigor — with verifiable attestations, signed provenance, and policy-based enforcement.
+
+For teams already pursuing SLSA compliance, DevOps Maturity can serve as a **companion assessment** covering the broader practices that SLSA does not address.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,31 @@
 [![DevOps Maturity](https://img.shields.io/badge/DevOps%20Maturity-Specification-yellow)](https://devops-maturity.github.io/)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Fdevops-maturity.github.io&up_color=yellow)](https://devops-maturity.github.io/)
 
-The DevOps Maturity specification is standardized to assess the maturity of DevOps practices. It is a set of questions and answers to help you measure and improve your DevOps maturity.
+The DevOps Maturity specification is standardized to assess the maturity of DevOps practices. It is a set of criteria to help you measure and improve your DevOps maturity.
+
+> DevOps Maturity is a **broad DevOps baseline assessment**. It does not replace specialized supply-chain security standards like [SLSA](https://slsa.dev/). See the [SLSA mapping](MAPPING-SLSA.md) for where the two frameworks overlap.
+
+## Schema
+
+The assessment file format is defined by a [JSON Schema](schema/devops-maturity.schema.json). Criteria accept both simple boolean values and structured objects with evidence, verification metadata, and rationale:
+
+```yaml
+# Simple boolean — quick self-assessment
+D101: true
+D202: false
+
+# Structured — auditable evidence
+D403:
+  status: true
+  evidence:
+    - type: workflow
+      path: .github/workflows/release.yml
+    - type: artifact-signature
+      tool: cosign
+  verified_by: devops-maturity-action
+  verified_at: "2026-05-24T00:00:00Z"
+  rationale: "Release workflow signs artifacts with Cosign keyless signing"
+```
 
 ## 🎉 Show Your Support
 
@@ -16,6 +40,11 @@ Let others know your project follows the DevOps Maturity specification. Add this
 ```markdown
 [![DevOps Maturity](https://img.shields.io/badge/DevOps%20Maturity-Specification-yellow)](https://devops-maturity.github.io/)
 ```
+
+## Additional Documents
+
+- **[MAPPING-SLSA.md](MAPPING-SLSA.md)** — Maps DevOps Maturity criteria to SLSA requirements
+- **[schema/devops-maturity.schema.json](schema/devops-maturity.schema.json)** — JSON Schema for the assessment YAML format
 
 ## 🤝 Contributing
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -12,6 +12,8 @@ layout: single
 
 The DevOps Maturity Specification is a set of guidelines and criteria designed to help organizations assess and improve their DevOps practices. It provides a structured approach to evaluate key areas such as Basics, Quality, Security, Supply Chain Security, Analysis, and Reporting. The specification is intended to align with best practices and provide a framework for continuous improvement within the DevOps community.
 
+> **Note:** DevOps Maturity is a broad DevOps baseline assessment, not a replacement for specialized standards like [SLSA](https://slsa.dev/) (supply-chain integrity) or [OpenSSF Scorecard](https://securityscorecards.dev/) (open-source security health). For supply-chain-specific criteria, see the [SLSA mapping](https://github.com/devops-maturity/spec/blob/main/MAPPING-SLSA.md).
+
 ### Key Points
 
 - **Purpose**: Help organizations and teams assess DevOps practices, align on best practices, and drive continuous improvement.
@@ -122,6 +124,10 @@ Your score will generate one of the following badges:
 ### What is the difference between OpenSSF Best Practices and DevOps Maturity?
 
 [OpenSSF Best Practices](https://www.bestpractices.dev/) targets open source projects across the entire software development lifecycle, while DevOps Maturity focuses specifically on DevOps practices applicable to both open source and internal enterprise projects. DevOps Maturity provides both a web UI and a CLI for automatic maturity scoring. In contrast, OpenSSF Best Practices only offers a web-based SaaS and does not support internal deployment.
+
+### How does DevOps Maturity relate to SLSA?
+
+DevOps Maturity does not replace SLSA — it complements it. SLSA is a specialized supply-chain integrity framework with rigorous attestation formats and verification rules. DevOps Maturity covers a wider surface: build, test, quality, security scanning, supply chain, analysis, and reporting. The supply-chain criteria (D4xx) map naturally to SLSA requirements, and teams can use DevOps Maturity as a first-step health check before pursuing deeper SLSA compliance. See the [SLSA mapping](https://github.com/devops-maturity/spec/blob/main/MAPPING-SLSA.md) for details.
 
 ### What is the difference between DevOps Maturity Model and DevOps Maturity Specification?
 

--- a/schema/devops-maturity.schema.json
+++ b/schema/devops-maturity.schema.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://devops-maturity.github.io/schema/devops-maturity.schema.json",
+  "title": "DevOps Maturity Assessment",
+  "description": "Schema for the devops-maturity.yml assessment file. Supports both simple boolean values and structured evidence objects for each criteria.",
+  "type": "object",
+  "required": ["project_name"],
+  "properties": {
+    "project_name": {
+      "type": "string",
+      "description": "Name of the project being assessed."
+    },
+    "project_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL of the project repository or homepage."
+    }
+  },
+  "patternProperties": {
+    "^D[1-6][0-9]{2}$": {
+      "description": "A criteria entry. Accepts a boolean (true/false) or a structured object with status and optional evidence.",
+      "oneOf": [
+        {
+          "type": "boolean",
+          "description": "Simple pass/fail for the criteria."
+        },
+        {
+          "type": "object",
+          "required": ["status"],
+          "properties": {
+            "status": {
+              "type": "boolean",
+              "description": "Whether the criteria is met."
+            },
+            "evidence": {
+              "type": "array",
+              "description": "Optional list of evidence items demonstrating how the criteria is met.",
+              "items": {
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "description": "Evidence type, e.g. workflow, artifact-signature, config, tool, report.",
+                    "examples": ["workflow", "artifact-signature", "config", "tool", "report"]
+                  },
+                  "path": {
+                    "type": "string",
+                    "description": "Path to the relevant file (e.g. CI workflow, config file)."
+                  },
+                  "tool": {
+                    "type": "string",
+                    "description": "Name of the tool used (e.g. cosign, trivy, codeql)."
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL pointing to the evidence (e.g. attestation, report)."
+                  }
+                },
+                "additionalProperties": true
+              }
+            },
+            "verified_by": {
+              "type": "string",
+              "description": "Tool or method that verified this criteria (e.g. devops-maturity-action, manual-review)."
+            },
+            "verified_at": {
+              "type": "string",
+              "format": "date-time",
+              "description": "ISO 8601 timestamp of verification."
+            },
+            "rationale": {
+              "type": "string",
+              "description": "Human-readable explanation of why this criteria is met."
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  },
+  "additionalProperties": true
+}


### PR DESCRIPTION
## Summary

Adds the structural foundation the spec was missing. Three key additions:

### 1. JSON Schema (`schema/devops-maturity.schema.json`)
- Validates both simple boolean and structured evidence formats
- Structured format: `{status, evidence, verified_by, verified_at, rationale}`
- Backward-compatible — existing YAML files remain valid

### 2. SLSA Mapping (`MAPPING-SLSA.md`)
- Maps D401–D405, D603 to SLSA requirements
- Clearly states: **DevOps Maturity does not replace SLSA**
- Explains where the two frameworks diverge
- Practical guidance for teams: DevOps Maturity as first-step health check, SLSA for deeper supply-chain rigor

### 3. Positioning Clarification
- `README.md` and `content/_index.md` updated with:
  - "DevOps Maturity is a broad DevOps baseline assessment, not a replacement for SLSA"
  - New FAQ: "How does DevOps Maturity relate to SLSA?"
  - Structured YAML example in README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SLSA mapping document clarifying DevOps Maturity framework alignment with SLSA supply-chain security concepts
  * Updated README with framework overview, schema documentation, and additional documents section
  * Added FAQ entry explaining how DevOps Maturity complements and relates to SLSA

* **New Features**
  * Introduced JSON Schema for defining and validating DevOps Maturity assessments structure

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devops-maturity/spec/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->