### PR TITLE
docs: add positioning / "How it compares" to spec site and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ The DevOps Maturity specification is standardized to assess the maturity of DevO
 
 > DevOps Maturity is a **broad DevOps baseline assessment**. It does not replace specialized supply-chain security standards like [SLSA](https://slsa.dev/). See the [SLSA mapping](MAPPING-SLSA.md) for where the two frameworks overlap.
 
+## How it compares
+
+DevOps Maturity is a **breadth-first, automatable baseline** across the whole delivery lifecycle. Adjacent frameworks go deeper but narrower, or measure outcomes rather than practices — they complement it rather than compete with it.
+
+| Framework | Primary focus | Best for |
+|---|---|---|
+| **DevOps Maturity** | DevOps **practices & controls** in place (build, quality, security, supply chain, analysis, reporting) | A fast, broad baseline + shareable badge for OSS **and** internal repos |
+| [DORA metrics](https://dora.dev/) | Delivery **outcomes** (deploy frequency, lead time, MTTR, change-fail rate) | Tracking delivery performance once practices exist |
+| [OpenSSF Scorecard](https://securityscorecards.dev/) | OSS security **health** (repo-level heuristics) | Hardening the security posture of a public repo |
+| [OpenSSF Best Practices](https://www.bestpractices.dev/) | OSS best-practice **badge** (web SaaS, self-attested) | Earning a recognized OSS badge |
+| [SLSA](https://slsa.dev/) | Supply-chain **integrity** (provenance & attestation) | Deep, verifiable supply-chain assurance |
+
+**What makes it different:** breadth beyond security; automatable end-to-end (YAML in, JSON/badge out, [GitHub Action](https://github.com/devops-maturity/devops-maturity-action) in CI); AI-powered auto-assessment from repo metadata; and CLI / self-hostable web UI that works on private repos with no SaaS lock-in.
+
+See the full comparison and "when to use which" on the [specification site](https://devops-maturity.github.io/).
+
 ## Schema
 
 The assessment file format is defined by a [JSON Schema](schema/devops-maturity.schema.json). Criteria accept both simple boolean values and structured objects with evidence, verification metadata, and rationale:

--- a/content/_index.md
+++ b/content/_index.md
@@ -24,6 +24,34 @@ The DevOps Maturity Specification is a set of guidelines and criteria designed t
 
 ---
 
+## How DevOps Maturity Compares
+
+DevOps Maturity is a **breadth-first, automatable baseline** for the whole delivery lifecycle. Most adjacent frameworks go deeper but narrower, or measure *outcomes* rather than *practices in place*. They are complements, not competitors.
+
+| Framework | Primary focus | Scope | How you run it | Best for |
+|---|---|---|---|---|
+| **DevOps Maturity** | DevOps **practices & controls** in place | Build, quality, security, supply chain, analysis, reporting | CLI · Web UI · GitHub Action · YAML · AI auto-assess | A fast, broad baseline + shareable badge for OSS **and** internal repos |
+| [DORA metrics](https://dora.dev/) | Delivery **outcomes** | Deploy frequency, lead time, MTTR, change-fail rate | Telemetry from your pipeline | Measuring delivery performance once practices exist |
+| [OpenSSF Scorecard](https://securityscorecards.dev/) | OSS security **health** | Repo-level security heuristics | Automated checks | Hardening the security posture of a public repo |
+| [OpenSSF Best Practices](https://www.bestpractices.dev/) | OSS best-practice **badge** | Whole SDLC, security-leaning | Web SaaS self-attestation | Earning a recognized OSS badge (SaaS only) |
+| [SLSA](https://slsa.dev/) | Supply-chain **integrity** | Build/source provenance & attestation | Attestation + verification | Deep, verifiable supply-chain assurance |
+| Traditional maturity models (CMMI-style) | Org **process** maturity | Broad, process-heavy | Consultant-led assessment | Large-scale, audited process programs |
+
+### What makes it different
+
+- **Breadth, not just security** — covers testing, quality, analysis, and reporting, not only supply-chain/security.
+- **Automatable end-to-end** — machine-readable YAML in, JSON/badge out; drop the [GitHub Action](https://github.com/devops-maturity/devops-maturity-action) into CI and the badge stays current on every change.
+- **AI-powered auto-assessment** — point it at a repo and an LLM infers the answers from README, CI config, and the file tree — no questionnaire required.
+- **Yours to run** — CLI or self-hostable web UI; works on private/internal repos, not just public OSS, with no SaaS lock-in.
+
+### When to use which
+
+- Start with **DevOps Maturity** for a quick, broad health check and a badge.
+- Add **DORA** to track delivery *outcomes* over time.
+- Layer **OpenSSF Scorecard / SLSA** for deeper security and supply-chain rigor once the D3xx/D4xx gaps are closed.
+
+---
+
 ## Specification
 
 | **Category**       | **Code**[^1]| **Criteria**[^2]            |**Req.**[^3]|
@@ -124,6 +152,14 @@ Your score will generate one of the following badges:
 ### What is the difference between OpenSSF Best Practices and DevOps Maturity?
 
 [OpenSSF Best Practices](https://www.bestpractices.dev/) targets open source projects across the entire software development lifecycle, while DevOps Maturity focuses specifically on DevOps practices applicable to both open source and internal enterprise projects. DevOps Maturity provides both a web UI and a CLI for automatic maturity scoring. In contrast, OpenSSF Best Practices only offers a web-based SaaS and does not support internal deployment.
+
+### How does DevOps Maturity relate to DORA metrics?
+
+They answer different questions. [DORA metrics](https://dora.dev/) measure delivery *outcomes* — how fast and how reliably you ship (deployment frequency, lead time, change-failure rate, time to restore). DevOps Maturity measures whether the *practices and controls* that produce those outcomes are actually in place. Use DevOps Maturity to find and close practice gaps, and DORA to track the performance results over time. They work well side by side.
+
+### How does DevOps Maturity relate to OpenSSF Scorecard?
+
+[OpenSSF Scorecard](https://securityscorecards.dev/) runs automated security-health checks on a repository and is focused on open-source security. DevOps Maturity is broader — it also covers testing, quality, analysis, and reporting — and works for internal/private projects, not only public OSS. Scorecard is a great way to deepen the security (D3xx) and supply-chain (D4xx) dimensions once a baseline is established.
 
 ### How does DevOps Maturity relate to SLSA?
 


### PR DESCRIPTION
## Why

From the org review, the biggest constraint isn't features — it's **positioning/distribution**. The spec is complete, but a visitor can't quickly answer *"why this over OpenSSF Scorecard / DORA / SLSA?"* The answer was buried in prose FAQ at the bottom of the page. This makes that the first thing they see.

## What

**`content/_index.md` (landing page)**
- New **"How DevOps Maturity Compares"** section near the top with a scannable matrix vs DORA, OpenSSF Scorecard, OpenSSF Best Practices, SLSA, and CMMI-style models.
- **"What makes it different"** (breadth beyond security · automatable end-to-end · AI auto-assessment · self-hostable, no SaaS lock-in).
- **"When to use which"** quick guide.
- Two new FAQ entries: **DORA** and **OpenSSF Scorecard** (SLSA / OpenSSF Best Practices entries already existed).

**`README.md`**
- Condensed "How it compares" table + differentiators so GitHub readers get the same framing at a glance, linking back to the site for the full version.

## Notes

- Docs-only; no schema or criteria changes.
- Framing is "complement, not competitor" — consistent with the existing SLSA mapping.
- Worth a local `hugo`/preview build to eyeball the new table rendering before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014T7TF835DAsBR9GMyZYjxC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the product overview with a new comparison section explaining how DevOps Maturity differs from other common frameworks.
  * Added a side-by-side comparison table and guidance on when each framework is most useful.
  * Updated the FAQ with clearer answers about how DevOps Maturity relates to DORA metrics and OpenSSF Scorecard.
  * Included a link to the full comparison for more detail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->