### PR TITLE
chore: group dependabot updates per ecosystem including security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,11 +10,31 @@ updates:
     npm-deps:
       patterns:
         - "*"
+    npm-deps-security:
+      applies-to: security-updates
+      patterns:
+        - "*"
 - package-ecosystem: github-actions
   directory: /
   schedule:
     interval: quarterly
   groups:
     github-action-deps:
+      patterns:
+        - "*"
+    github-action-deps-security:
+      applies-to: security-updates
+      patterns:
+        - "*"
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: quarterly
+  groups:
+    docker-deps:
+      patterns:
+        - "*"
+    docker-deps-security:
+      applies-to: security-updates
       patterns:
         - "*"


### PR DESCRIPTION
## Summary

Group Dependabot updates per package ecosystem, including security updates.

## Background / root cause

The config already had `groups` for npm (`npm-deps`) and github-actions (`github-action-deps`), but only for **version updates** — Dependabot's `groups` default to `applies-to: version-updates`, and **security updates are never grouped unless explicitly opted in**. That is why #59 (immutable), #60 (postcss) and #61 (fast-uri) each got their own PR: they are security updates (GHSA advisories, see the open Dependabot alerts) and were outside the existing groups.

Also, the repo has `Dockerfile` + `Dockerfile.dev` but **no docker ecosystem entry at all**, so base-image updates were never tracked.

## Changes

`.github/dependabot.yml`:

1. **npm** — keep `npm-deps` (version updates), add `npm-deps-security` with `applies-to: security-updates`
2. **github-actions** — keep `github-action-deps`, add `github-action-deps-security`
3. **docker (new)** — `directory: /` covers both `Dockerfile` and `Dockerfile.dev` (Dependabot scans all files matching the Dockerfile pattern), with `docker-deps` + `docker-deps-security` groups

## Result

Going forward, each ecosystem gets:
- one grouped PR for routine version bumps
- one grouped PR for security bumps (instead of one PR per vulnerable dependency)

Existing open PRs (#57, #59–#61) are unaffected; future updates will use the groups.

Validated: YAML parses; groups per ecosystem: npm [npm-deps, npm-deps-security], github-actions [github-action-deps, github-action-deps-security], docker [docker-deps, docker-deps-security].


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update management by grouping security updates by ecosystem.
  * Added quarterly scanning for Docker dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->